### PR TITLE
Improve sensors page style and dialog

### DIFF
--- a/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.module.css
@@ -1,0 +1,44 @@
+.overlay {
+  background: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  inset: 0;
+}
+
+.content {
+  background: var(--content-bg);
+  color: var(--foreground);
+  border-radius: 8px;
+  padding: 24px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 300px;
+  display: grid;
+  gap: 12px;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+}
+
+.form input {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.form button {
+  padding: 8px 12px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.tsx
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Dialog } from 'radix-ui';
+import styles from './SensorFormDialog.module.css';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { useSensorMutations } from '@/hooks/useSensors';
@@ -31,22 +32,25 @@ export default function SensorFormDialog({ open, onOpenChange, initial }: {
 		action.then(() => onOpenChange(false));
 	};
 
-	return (
-		<Dialog.Root open={open} onOpenChange={onOpenChange}>
-			<Dialog.Portal>
-				<Dialog.Content>
-					<Dialog.Title>{initial ? 'Edit sensor' : 'New sensor'}</Dialog.Title>
-					<Dialog.Description id="sensor-desc">
-						{initial ? 'Update sensor parameters.' : 'Create a new sensor.'}
-					</Dialog.Description>
-					<form onSubmit={handleSubmit(onSubmit)} style={{ display: 'grid', gap: 12 }}>
-						<input placeholder="Name" {...register('name')} />
-						{errors.name && <span>{errors.name.message}</span>}
-						<input placeholder="Location" {...register('location')} />
-						<button disabled={isSubmitting}>{initial ? 'Save' : 'Create'}</button>
-					</form>
-				</Dialog.Content>
-			</Dialog.Portal>
-		</Dialog.Root>
-	);
+        return (
+                <Dialog.Root open={open} onOpenChange={onOpenChange}>
+                        <Dialog.Portal>
+                                <Dialog.Overlay className={styles.overlay} />
+                                <Dialog.Content className={styles.content}>
+                                        <Dialog.Title className={styles.title}>
+                                                {initial ? 'Edit sensor' : 'New sensor'}
+                                        </Dialog.Title>
+                                        <Dialog.Description id="sensor-desc">
+                                                {initial ? 'Update sensor parameters.' : 'Create a new sensor.'}
+                                        </Dialog.Description>
+                                        <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+                                                <input placeholder="Name" {...register('name')} />
+                                                {errors.name && <span>{errors.name.message}</span>}
+                                                <input placeholder="Location" {...register('location')} />
+                                                <button disabled={isSubmitting}>{initial ? 'Save' : 'Create'}</button>
+                                        </form>
+                                </Dialog.Content>
+                        </Dialog.Portal>
+                </Dialog.Root>
+        );
 }

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
@@ -1,0 +1,28 @@
+.addButton {
+  margin-bottom: 16px;
+  padding: 6px 12px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ddd;
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.actions button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-right: 4px;
+}

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.tsx
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import SensorFormDialog from '@/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog';
 import { useSensorMutations, useSensors } from '@/hooks/useSensors';
 import type { Sensor } from '@/services/api/types';
+import styles from './SensorsTable.module.css';
 
 function SensorTable() {
 	const { data = [], isLoading } = useSensors();
@@ -34,32 +35,42 @@ function SensorTable() {
 
 	const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
 
-	if (isLoading) return <p>Loading…</p>;
+        if (isLoading) return <p>Loading…</p>;
 
-	return (
-		<>
-			<button onClick={() => { setEditSensor(undefined); setOpen(true); }}>➕ Add sensor</button>
+        return (
+                <>
+                        <button
+                                className={styles.addButton}
+                                onClick={() => {
+                                        setEditSensor(undefined);
+                                        setOpen(true);
+                                }}
+                        >
+                                ➕ Add sensor
+                        </button>
 
-			<table>
-				<thead>
-					{table.getHeaderGroups().map((hg) => (
-						<tr key={hg.id}>
-							{hg.headers.map((h) => (
-								<th key={h.id}>{flexRender(h.column.columnDef.header, h.getContext())}</th>
-							))}
-						</tr>
-					))}
-				</thead>
-				<tbody>
-					{table.getRowModel().rows.map((row) => (
-						<tr key={row.id}>
-							{row.getVisibleCells().map((cell) => (
-								<td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
-							))}
-						</tr>
-					))}
-				</tbody>
-			</table>
+                        <table className={styles.table}>
+                                <thead>
+                                        {table.getHeaderGroups().map((hg) => (
+                                                <tr key={hg.id}>
+                                                        {hg.headers.map((h) => (
+                                                                <th key={h.id}>{flexRender(h.column.columnDef.header, h.getContext())}</th>
+                                                        ))}
+                                                </tr>
+                                        ))}
+                                </thead>
+                                <tbody>
+                                        {table.getRowModel().rows.map((row) => (
+                                                <tr key={row.id}>
+                                                        {row.getVisibleCells().map((cell) => (
+                                                                <td key={cell.id} className={cell.column.id === 'actions' ? styles.actions : undefined}>
+                                                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                                                </td>
+                                                        ))}
+                                                </tr>
+                                        ))}
+                                </tbody>
+                        </table>
 
 			<SensorFormDialog
 				open={isOpen}

--- a/frontend/src/app/(dashboard)/sensors/page.module.css
+++ b/frontend/src/app/(dashboard)/sensors/page.module.css
@@ -1,0 +1,11 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: 600;
+}

--- a/frontend/src/app/(dashboard)/sensors/page.tsx
+++ b/frontend/src/app/(dashboard)/sensors/page.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import SensorTable from '@/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable';
+import styles from './page.module.css';
 
 function SensorsPage() {
-	return (
-		<main style={{ padding: 24 }}>
-			<h1>Sensors</h1>
-			<SensorTable />
-		</main>
-	);
+        return (
+                <main className={styles.main}>
+                        <h1 className={styles.title}>Sensors</h1>
+                        <SensorTable />
+                </main>
+        );
 }
 
 export default SensorsPage;


### PR DESCRIPTION
## Summary
- style sensors page with a CSS module
- style the sensors table and dialog
- make the dialog visible with overlay and content styling

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a559864808331a5fa8bbbe73b3c12