### PR TITLE
Fix sensor table actions and sorting

### DIFF
--- a/backend/app/api/sensors.py
+++ b/backend/app/api/sensors.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.module.css
@@ -41,4 +41,13 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+}
+
+.form button:hover {
+  background: color-mix(in srgb, var(--accent) 80%, #ffffff);
+}
+
+.form button:active {
+  transform: scale(0.97);
 }

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.tsx
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.tsx
@@ -3,6 +3,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Dialog } from 'radix-ui';
 import styles from './SensorFormDialog.module.css';
 import { useForm } from 'react-hook-form';
+import { useEffect } from 'react';
 import { z } from 'zod';
 import { useSensorMutations } from '@/hooks/useSensors';
 
@@ -18,14 +19,19 @@ export default function SensorFormDialog({ open, onOpenChange, initial }: {
 	initial?: { id: number; name: string; location?: string };
 }) {
 	const { create, update } = useSensorMutations();
-	const {
-		register,
-		handleSubmit,
-		formState: { errors, isSubmitting },
-	} = useForm<FormData>({
-		resolver: zodResolver(schema),
-		defaultValues: initial ?? { name: '', location: '' },
-	});
+        const {
+                register,
+                handleSubmit,
+                formState: { errors, isSubmitting },
+                reset,
+        } = useForm<FormData>({
+                resolver: zodResolver(schema),
+                defaultValues: { name: '', location: '' },
+        });
+
+        useEffect(() => {
+                reset(initial ? { name: initial.name, location: initial.location ?? '' } : { name: '', location: '' });
+        }, [initial, reset]);
 
 	const onSubmit = (data: FormData) => {
 		const action = initial ? update.mutateAsync({ id: initial.id, data }) : create.mutateAsync(data);

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
@@ -20,9 +20,36 @@
   text-align: left;
 }
 
+.actions {
+  display: flex;
+  gap: 4px;
+}
+
 .actions button {
   background: none;
   border: none;
   cursor: pointer;
-  margin-right: 4px;
+}
+
+.iconButton {
+  padding: 4px;
+  border-radius: 4px;
+  transition: background 0.2s, transform 0.1s;
+}
+
+.iconButton:hover {
+  background: var(--sidebar-hover);
+}
+
+.iconButton:active {
+  transform: scale(0.95);
+}
+
+.delete {
+  color: #ef4444;
+}
+
+.headerCell {
+  cursor: pointer;
+  user-select: none;
 }

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.tsx
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.tsx
@@ -1,9 +1,11 @@
 'use client';
 import {
-	createColumnHelper,
-	useReactTable,
-	getCoreRowModel,
-	flexRender,
+        createColumnHelper,
+        useReactTable,
+        getCoreRowModel,
+        getSortedRowModel,
+        flexRender,
+        SortingState,
 } from '@tanstack/react-table';
 import { useState } from 'react';
 import SensorFormDialog from '@/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog';
@@ -14,26 +16,58 @@ import styles from './SensorsTable.module.css';
 function SensorTable() {
 	const { data = [], isLoading } = useSensors();
 	const { remove } = useSensorMutations();
-	const [editSensor, setEditSensor] = useState<Sensor | undefined>(undefined);
-	const [isOpen, setOpen] = useState(false);
+        const [editSensor, setEditSensor] = useState<Sensor | undefined>(undefined);
+        const [isOpen, setOpen] = useState(false);
+        const [sorting, setSorting] = useState<SortingState>([]);
 
 	const column = createColumnHelper<Sensor>();
-	const columns = [
-		column.accessor('id', { header: 'ID' }),
-		column.accessor('name', { header: 'Name' }),
-		column.accessor('location', { header: 'Location' }),
-		column.display({
-			id: 'actions',
-			cell: ({ row }) => (
-    <>
-        <button onClick={() => { setEditSensor(row.original); setOpen(true); }}>✏️</button>
-        <button onClick={() => remove.mutate(row.original.id)}>🗑️</button>
-    </>
-			),
-		}),
-	];
+        const columns = [
+                column.accessor('id', {
+                        header: () => 'ID',
+                        sortingFn: 'auto',
+                }),
+                column.accessor('name', {
+                        header: () => 'Name',
+                        sortingFn: 'auto',
+                }),
+                column.accessor('location', {
+                        header: () => 'Location',
+                        sortingFn: 'auto',
+                }),
+                column.display({
+                        id: 'actions',
+                        cell: ({ row }) => (
+                                <div className={styles.actions}>
+                                        <button
+                                                className={styles.iconButton}
+                                                aria-label="Edit"
+                                                onClick={() => {
+                                                        setEditSensor(row.original);
+                                                        setOpen(true);
+                                                }}
+                                        >
+                                                ✏️
+                                        </button>
+                                        <button
+                                                className={`${styles.iconButton} ${styles.delete}`}
+                                                aria-label="Delete"
+                                                onClick={() => remove.mutate(row.original.id)}
+                                        >
+                                                🗑️
+                                        </button>
+                                </div>
+                        ),
+                }),
+        ];
 
-	const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+        const table = useReactTable({
+                data,
+                columns,
+                state: { sorting },
+                onSortingChange: setSorting,
+                getCoreRowModel: getCoreRowModel(),
+                getSortedRowModel: getSortedRowModel(),
+        });
 
         if (isLoading) return <p>Loading…</p>;
 
@@ -54,7 +88,16 @@ function SensorTable() {
                                         {table.getHeaderGroups().map((hg) => (
                                                 <tr key={hg.id}>
                                                         {hg.headers.map((h) => (
-                                                                <th key={h.id}>{flexRender(h.column.columnDef.header, h.getContext())}</th>
+                                                                <th
+                                                                        key={h.id}
+                                                                        onClick={h.column.getToggleSortingHandler()}
+                                                                        className={styles.headerCell}
+                                                                >
+                                                                        {flexRender(h.column.columnDef.header, h.getContext())}
+                                                                        {h.column.getIsSorted() ? (
+                                                                                h.column.getIsSorted() === 'asc' ? ' \u25B2' : ' \u25BC'
+                                                                        ) : ''}
+                                                                </th>
                                                         ))}
                                                 </tr>
                                         ))}

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -16,11 +16,16 @@ export async function request<T>(
 		...init,
 	});
 
-	if (!res.ok) {
-		throw new Error(`${res.status}: ${res.statusText}`);
-	}
+        if (!res.ok) {
+                throw new Error(`${res.status}: ${res.statusText}`);
+        }
 
-	return res.json();
+        if (res.status === 204) {
+                // no content
+                return null as T;
+        }
+
+        return res.json();
 }
 
 export const http = {


### PR DESCRIPTION
## Summary
- improve API helper to handle 204 responses
- reset form values when editing a sensor
- add sorting to the sensor table
- style action buttons with modern look
- polish dialog button interactions

## Testing
- `npx tsc -p frontend/tsconfig.json --noEmit` *(fails: Cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_687a58552ce08331b8a7c915ccb7a8d1