### PR TITLE
Enhance dashboard UI

### DIFF
--- a/frontend/src/app/(dashboard)/dashboard/page.module.css
+++ b/frontend/src/app/(dashboard)/dashboard/page.module.css
@@ -1,0 +1,40 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  height: 100%;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.sensorSelect {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sensorSelect select {
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: var(--content-bg);
+  color: var(--foreground);
+}
+
+.card {
+  background: var(--content-bg);
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/frontend/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Chart from '@/components/Chart/Chart';
 import ReadingsTable from '@/components/ReadingsTable/ReadingsTable';
 import { useReadings } from '@/hooks/useReadings';
 import { useSensors } from '@/hooks/useSensors';
+import styles from './page.module.css';
 
 function Dashboard() {
 	const { data: sensors = [] } = useSensors();
@@ -12,29 +13,35 @@ function Dashboard() {
 
 	const readingsQuery = useReadings(sensorId);
 
-	return (
-		<main>
-			<h1>Real-Time Sensor Dashboard</h1>
+        return (
+                <main className={styles.main}>
+                        <div className={styles.header}>
+                                <h1 className={styles.title}>Real-Time Sensor Dashboard</h1>
 
-			<label>
-				Sensor:
-				<select
-					value={sensorId}
-					onChange={(e) => setSensorId(Number(e.target.value))}
-				>
-					{sensors.map((sensor) => (
-						<option key={sensor.id} value={sensor.id}>
-							{sensor.name}
-						</option>
-						))}
-				</select>
-			</label>
+                                <label className={styles.sensorSelect}>
+                                        Sensor:
+                                        <select
+                                                value={sensorId}
+                                                onChange={(e) => setSensorId(Number(e.target.value))}
+                                        >
+                                                {sensors.map((sensor) => (
+                                                        <option key={sensor.id} value={sensor.id}>
+                                                                {sensor.name}
+                                                        </option>
+                                                        ))}
+                                        </select>
+                                </label>
+                        </div>
 
-			<Chart data={readingsQuery.data ?? []} />
+                        <div className={styles.card}>
+                                <Chart data={readingsQuery.data ?? []} />
+                        </div>
 
-			<ReadingsTable data={readingsQuery.data ?? []} isLoading={readingsQuery.isLoading} />
-		</main>
-	);
+                        <div className={styles.card}>
+                                <ReadingsTable data={readingsQuery.data ?? []} isLoading={readingsQuery.isLoading} />
+                        </div>
+                </main>
+        );
 }
 
 export default Dashboard;

--- a/frontend/src/components/Chart/Chart.module.css
+++ b/frontend/src/components/Chart/Chart.module.css
@@ -1,0 +1,4 @@
+.chartWrapper {
+  width: 100%;
+  height: 300px;
+}

--- a/frontend/src/components/Chart/Chart.tsx
+++ b/frontend/src/components/Chart/Chart.tsx
@@ -1,10 +1,11 @@
 'use client';
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
 import type { Reading } from '@/services/api/types';
+import styles from './Chart.module.css';
 
 function Chart({ data }: { data: Reading[] }) {
-	return (
-        <div style={{ width: '100%', height: 300, marginTop: 24 }}>
+        return (
+        <div className={styles.chartWrapper}>
             <ResponsiveContainer>
                 <LineChart data={[...data].reverse()}>
                     <XAxis dataKey="timestamp" tickFormatter={(t) => new Date(t).toLocaleTimeString()} />

--- a/frontend/src/components/ReadingsTable/ReadingsTable.module.css
+++ b/frontend/src/components/ReadingsTable/ReadingsTable.module.css
@@ -1,0 +1,21 @@
+.wrapper {
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ddd;
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.headerCell {
+  cursor: pointer;
+  user-select: none;
+}

--- a/frontend/src/components/ReadingsTable/ReadingsTable.tsx
+++ b/frontend/src/components/ReadingsTable/ReadingsTable.tsx
@@ -9,6 +9,7 @@ import {
 import { useState } from 'react';
 import type { Reading } from '@/services/api/types';
 import type { ColumnDef, SortingState } from '@tanstack/react-table';
+import styles from './ReadingsTable.module.css';
 
 const columns: ColumnDef<Reading>[] = [
 	{
@@ -39,9 +40,9 @@ function ReadingsTable({ data, isLoading }: {
 
 	if (isLoading) return <p>Loading data…</p>;
 
-	return (
-    	<div style={{ maxHeight: 260, overflowY: 'auto', marginTop: 24 }}>
-        <table>
+        return (
+        <div className={styles.wrapper}>
+        <table className={styles.table}>
             <thead>
                 {table.getHeaderGroups().map((hg) => (
                     <tr key={hg.id}>
@@ -49,7 +50,7 @@ function ReadingsTable({ data, isLoading }: {
                             <th
                                 key={h.id}
                                 onClick={h.column.getToggleSortingHandler()}
-                                style={{ cursor: 'pointer' }}
+                                className={styles.headerCell}
                             >
                                 {flexRender(h.column.columnDef.header, h.getContext())}
                                 {h.column.getIsSorted() === 'asc' ? ' ▲' : h.column.getIsSorted() === 'desc' ? ' ▼' : ''}


### PR DESCRIPTION
## Summary
- add styled cards and header to the dashboard page
- move chart and table styling into CSS modules

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5d2c4d348331bbe55af94e805c57