### PR TITLE
Fix sensor-specific websocket reading

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,11 +37,13 @@ app.include_router(readings.router)
 @app.websocket("/ws/readings")
 async def websocket_endpoint(ws: WebSocket):
     await ws.accept()
+    sensor_id = int(ws.query_params.get("sensor_id", 1))
+
     try:
         while True:
             reading = {
                 "timestamp": datetime.utcnow().isoformat(),
-                "sensor_id": 1,
+                "sensor_id": sensor_id,
                 "temperature": round(random.uniform(20, 30), 2),
                 "humidity": round(random.uniform(40, 60), 1),
             }

--- a/frontend/src/hooks/useReadings.ts
+++ b/frontend/src/hooks/useReadings.ts
@@ -15,7 +15,9 @@ export function useReadings(sensorId: number) {
 	useEffect(() => {
 		if (!sensorId) return;
 
-		const ws = new WebSocket(`${location.origin.replace(/^http/, 'ws')}/ws/readings`);
+                const ws = new WebSocket(
+                        `${location.origin.replace(/^http/, 'ws')}/ws/readings?sensor_id=${sensorId}`,
+                );
 
 		ws.onmessage = (evt) => {
 			const reading: Reading = JSON.parse(evt.data);
@@ -27,7 +29,11 @@ export function useReadings(sensorId: number) {
 			]);
 		};
 
-		return () => ws.close();
+                return () => {
+                        if (ws.readyState <= WebSocket.OPEN) {
+                                ws.close();
+                        }
+                };
 	}, [sensorId, qc]);
 
 	return query;


### PR DESCRIPTION
## Summary
- support sensor_id query parameter in backend websocket endpoint
- update frontend hook to include sensor_id and close websockets gracefully

## Testing
- `npm run lint` *(fails: `next` not found)*
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a5f1292708331aeb8c247484ddb08