### PR TITLE
Fix sensor endpoints and update websocket interval

### DIFF
--- a/backend/app/api/sensors.py
+++ b/backend/app/api/sensors.py
@@ -30,7 +30,7 @@ async def create_sensor(data: SensorIn, db: AsyncSession = Depends(get_db)):
     await db.refresh(sensor)
     return sensor
 
-@router.put("/{sensor_id}/", response_model=SensorOut)
+@router.put("/{sensor_id}", response_model=SensorOut)
 async def update_sensor(
     sensor_id: int, data: SensorIn, db: AsyncSession = Depends(get_db)
 ):
@@ -45,7 +45,7 @@ async def update_sensor(
     return sensor
 
 
-@router.delete("/{sensor_id}/", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{sensor_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_sensor(sensor_id: int, db: AsyncSession = Depends(get_db)):
     sensor = await db.get(Sensor, sensor_id)
     if not sensor:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,6 @@ async def websocket_endpoint(ws: WebSocket):
                 "humidity": round(random.uniform(40, 60), 1),
             }
             await ws.send_json(reading)
-            await asyncio.sleep(1)
+            await asyncio.sleep(4)
     except Exception:
         await ws.close()

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -41,7 +41,7 @@ export const http = {
 export const api = {
 	getSensors: () => http.get<Sensor[]>('/sensors'),
 	createSensor: (payload: SensorIn)=> http.post<SensorIn>('/sensors', payload),
-	updateSensor: (id: number, data: SensorIn) => http.put<Sensor>(`/sensors/${id}/`, data),
-	deleteSensor: (id: number) => http.delete<void>(`/sensors/${id}/`),
+  updateSensor: (id: number, data: SensorIn) => http.put<Sensor>(`/sensors/${id}`, data),
+  deleteSensor: (id: number) => http.delete<void>(`/sensors/${id}`),
 	getReadings: (sensorId: number, limit = 100) => http.get<Reading[]>(`/readings?sensor_id=${sensorId}&limit=${limit}`),
 };


### PR DESCRIPTION
## Summary
- adjust WebSocket sample rate to every 4 seconds
- use trailing-slash free sensor paths on backend
- update frontend API client to match new endpoints

## Testing
- `npm run lint` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687a6189f7ac83318b1a5dc78dff85e7