### PR TITLE
Improve empty states and styling

### DIFF
--- a/frontend/src/app/(dashboard)/dashboard/page.module.css
+++ b/frontend/src/app/(dashboard)/dashboard/page.module.css
@@ -26,15 +26,22 @@
 
 .sensorSelect select {
   padding: 6px 12px;
-  border-radius: 4px;
-  border: 1px solid #ccc;
+  border-radius: 8px;
+  border: 1px solid #444;
   background: var(--content-bg);
   color: var(--foreground);
 }
 
 .card {
   background: var(--content-bg);
-  border-radius: 8px;
+  border-radius: 12px;
   padding: 16px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.emptyState {
+  background: var(--content-bg);
+  border-radius: 12px;
+  padding: 24px;
+  text-align: center;
 }

--- a/frontend/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import Chart from '@/components/Chart/Chart';
 import ReadingsTable from '@/components/ReadingsTable/ReadingsTable';
 import { useReadings } from '@/hooks/useReadings';
@@ -8,10 +9,28 @@ import { useSensors } from '@/hooks/useSensors';
 import styles from './page.module.css';
 
 function Dashboard() {
-	const { data: sensors = [] } = useSensors();
-	const [sensorId, setSensorId] = useState<number>(sensors[0]?.id || 0);
+        const { data: sensors = [], isLoading } = useSensors();
+        const [sensorId, setSensorId] = useState<number>(sensors[0]?.id || 0);
 
-	const readingsQuery = useReadings(sensorId);
+        const readingsQuery = useReadings(sensorId);
+
+        if (isLoading) {
+                return (
+                        <main className={styles.main}>
+                                <p>Loading…</p>
+                        </main>
+                );
+        }
+
+        if (sensors.length === 0) {
+                return (
+                        <main className={styles.main}>
+                                <div className={styles.emptyState}>
+                                        <p>No sensors found. <Link href="/sensors">Add a sensor</Link> to get started.</p>
+                                </div>
+                        </main>
+                );
+        }
 
         return (
                 <main className={styles.main}>

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.module.css
@@ -7,7 +7,7 @@
 .content {
   background: var(--content-bg);
   color: var(--foreground);
-  border-radius: 8px;
+  border-radius: 12px;
   padding: 24px;
   position: fixed;
   top: 50%;
@@ -30,8 +30,8 @@
 
 .form input {
   padding: 8px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  border: 1px solid #444;
+  border-radius: 8px;
 }
 
 .form button {
@@ -39,7 +39,7 @@
   background: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 8px;
   cursor: pointer;
   transition: background 0.2s, transform 0.1s;
 }

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
@@ -1,21 +1,32 @@
 .addButton {
   margin-bottom: 16px;
-  padding: 6px 12px;
+  padding: 8px 16px;
   background: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 8px;
   cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+}
+
+.addButton:hover {
+  background: color-mix(in srgb, var(--accent) 80%, #ffffff);
+}
+
+.addButton:active {
+  transform: scale(0.97);
 }
 
 .table {
   width: 100%;
   border-collapse: collapse;
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .table th,
 .table td {
-  border: 1px solid #ddd;
+  border: 1px solid #444;
   padding: 8px 12px;
   text-align: left;
 }
@@ -33,7 +44,7 @@
 
 .iconButton {
   padding: 4px;
-  border-radius: 4px;
+  border-radius: 8px;
   transition: background 0.2s, transform 0.1s;
 }
 
@@ -52,4 +63,11 @@
 .headerCell {
   cursor: pointer;
   user-select: none;
+}
+
+.empty {
+  background: var(--content-bg);
+  border-radius: 12px;
+  padding: 24px;
+  text-align: center;
 }

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.tsx
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.tsx
@@ -14,8 +14,8 @@ import type { Sensor } from '@/services/api/types';
 import type { SortingState } from '@tanstack/react-table';
 
 function SensorTable() {
-	const { data = [], isLoading } = useSensors();
-	const { remove } = useSensorMutations();
+        const { data = [], isLoading } = useSensors();
+        const { remove } = useSensorMutations();
         const [editSensor, setEditSensor] = useState<Sensor | undefined>(undefined);
         const [isOpen, setOpen] = useState(false);
         const [sorting, setSorting] = useState<SortingState>([]);
@@ -71,19 +71,27 @@ function SensorTable() {
 
         if (isLoading) return <p>Loading…</p>;
 
+        const handleAdd = () => {
+                setEditSensor(undefined);
+                setOpen(true);
+        };
+
         return (
                 <>
-                        <button
-                                className={styles.addButton}
-                                onClick={() => {
-                                        setEditSensor(undefined);
-                                        setOpen(true);
-                                }}
-                        >
-                                ➕ Add sensor
-                        </button>
+                        {data.length === 0 ? (
+                                <div className={styles.empty}>
+                                        <p>No sensors yet. Add your first sensor.</p>
+                                        <button className={styles.addButton} onClick={handleAdd}>
+                                                ➕ Add sensor
+                                        </button>
+                                </div>
+                        ) : (
+                                <>
+                                        <button className={styles.addButton} onClick={handleAdd}>
+                                                ➕ Add sensor
+                                        </button>
 
-                        <table className={styles.table}>
+                                        <table className={styles.table}>
                                 <thead>
                                         {table.getHeaderGroups().map((hg) => (
                                                 <tr key={hg.id}>
@@ -114,14 +122,16 @@ function SensorTable() {
                                         ))}
                                 </tbody>
                         </table>
+                                </>
+                        )}
 
-			<SensorFormDialog
-				open={isOpen}
-				onOpenChange={setOpen}
-				initial={editSensor}
-			/>
-		</>
-	);
+                        <SensorFormDialog
+                                open={isOpen}
+                                onOpenChange={setOpen}
+                                initial={editSensor}
+                        />
+                </>
+        );
 }
 
 export default SensorTable;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,22 +1,22 @@
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --sidebar-bg: rgb(14, 25, 20);
-  --sidebar-color: white;
-  --sidebar-text: #111;
-  --sidebar-hover: #f3f4f6;
-  --accent: #3b82f6;
-  --content-bg: #fafafa;
+  --background: #0f0f16;
+  --foreground: #f5f5f7;
+  --sidebar-bg: #13151f;
+  --sidebar-color: #ffffff;
+  --sidebar-text: #ffffff;
+  --sidebar-hover: #23253a;
+  --accent: #7c3aed;
+  --content-bg: #1b1d2b;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-    --sidebar-bg: #1f2937;
-    --sidebar-text: #e5e7eb;
-    --sidebar-hover: #374151;
-    --content-bg: #111827;
+    --background: #0f0f16;
+    --foreground: #f5f5f7;
+    --sidebar-bg: #13151f;
+    --sidebar-text: #ffffff;
+    --sidebar-hover: #23253a;
+    --content-bg: #1b1d2b;
   }
 }
 

--- a/frontend/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/src/components/Sidebar/Sidebar.module.css
@@ -6,21 +6,25 @@
     display: flex;
     flex-direction: column;
     gap: 24px;
+    border-radius: 12px 0 0 12px;
 }
 
 .navListItem {
     padding: 12px;
+    border-radius: 8px;
 }
 
 .navListLink {
     border-bottom: 1px solid transparent;
-    transition: border-bottom 0.2s;
+    transition: background 0.2s, border-bottom 0.2s;
 
     &:hover {
+        background: var(--sidebar-hover);
         border-color: var(--sidebar-color);
     }
 }
 
 .active {
+    background: var(--sidebar-hover);
     border-color: var(--sidebar-color);
 }


### PR DESCRIPTION
## Summary
- add helpful empty state to dashboard when no sensors exist
- add empty state to sensors table and style add button
- restyle dialog fields and sidebar
- tweak global theme to match Token Security colors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a63f23cf88331bdc93422cb5fe1e9