### PR TITLE
Implement browser theme preference

### DIFF
--- a/frontend/src/app/(dashboard)/dashboard/page.module.css
+++ b/frontend/src/app/(dashboard)/dashboard/page.module.css
@@ -27,7 +27,7 @@
 .sensorSelect select {
   padding: 6px 12px;
   border-radius: 8px;
-  border: 1px solid #444;
+  border: 1px solid var(--border-color);
   background: var(--content-bg);
   color: var(--foreground);
 }

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog.module.css
@@ -30,7 +30,7 @@
 
 .form input {
   padding: 8px;
-  border: 1px solid #444;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
 }
 

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
@@ -17,16 +17,18 @@
   transform: scale(0.97);
 }
 
+
 .table {
   width: 100%;
   border-collapse: collapse;
   border-radius: 8px;
   overflow: hidden;
+  border: 1px solid var(--border-color);
 }
 
 .table th,
 .table td {
-  border: 1px solid #444;
+  border: 1px solid var(--border-color);
   padding: 8px 12px;
   text-align: left;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,22 +1,26 @@
 :root {
-  --background: #0f0f16;
-  --foreground: #f5f5f7;
+  /* light mode is default */
+  --background: #ffffff;
+  --foreground: #1a1a1a;
   --sidebar-bg: #13151f;
   --sidebar-color: #ffffff;
   --sidebar-text: #ffffff;
   --sidebar-hover: #23253a;
   --accent: #7c3aed;
-  --content-bg: #1b1d2b;
+  --content-bg: #f0f0f3;
+  --border-color: #ccc;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0f0f16;
     --foreground: #f5f5f7;
+    /* sidebar remains dark in both themes */
     --sidebar-bg: #13151f;
     --sidebar-text: #ffffff;
     --sidebar-hover: #23253a;
     --content-bg: #1b1d2b;
+    --border-color: #444;
   }
 }
 
@@ -49,6 +53,10 @@ ul {
   list-style: none;
   padding: 0;
   margin: 0;
+}
+
+html {
+  color-scheme: light;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/frontend/src/components/ReadingsTable/ReadingsTable.module.css
+++ b/frontend/src/components/ReadingsTable/ReadingsTable.module.css
@@ -6,11 +6,14 @@
 .table {
   width: 100%;
   border-collapse: collapse;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
 }
 
 .table th,
 .table td {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   padding: 8px 12px;
   text-align: left;
 }


### PR DESCRIPTION
## Summary
- support light and dark modes via `prefers-color-scheme`
- keep sidebar dark for both themes
- add consistent border color variable
- restore table corner radius
- adjust form and dropdown borders

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6785ddec8331a7ad5b2f8ba0afc3