### PR TITLE
Unify table component and adjust styles

### DIFF
--- a/frontend/src/app/(dashboard)/dashboard/page.module.css
+++ b/frontend/src/app/(dashboard)/dashboard/page.module.css
@@ -36,7 +36,6 @@
   background: var(--content-bg);
   border-radius: 12px;
   padding: 16px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .emptyState {

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.module.css
@@ -18,20 +18,6 @@
 }
 
 
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  border-radius: 8px;
-  overflow: hidden;
-  border: 1px solid var(--border-color);
-}
-
-.table th,
-.table td {
-  border: 1px solid var(--border-color);
-  padding: 8px 12px;
-  text-align: left;
-}
 
 .actions {
   display: flex;
@@ -62,10 +48,6 @@
   color: #ef4444;
 }
 
-.headerCell {
-  cursor: pointer;
-  user-select: none;
-}
 
 .empty {
   background: var(--content-bg);

--- a/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.tsx
+++ b/frontend/src/app/(dashboard)/sensors/_components/SensorsTable/SensorsTable.tsx
@@ -4,11 +4,11 @@ import {
         useReactTable,
         getCoreRowModel,
         getSortedRowModel,
-        flexRender,
 } from '@tanstack/react-table';
 import { useState } from 'react';
 import SensorFormDialog from '@/app/(dashboard)/sensors/_components/SensorFormDialog/SensorFormDialog';
 import { useSensorMutations, useSensors } from '@/hooks/useSensors';
+import DataTable from '@/components/DataTable/DataTable';
 import styles from './SensorsTable.module.css';
 import type { Sensor } from '@/services/api/types';
 import type { SortingState } from '@tanstack/react-table';
@@ -91,37 +91,12 @@ function SensorTable() {
                                                 ➕ Add sensor
                                         </button>
 
-                                        <table className={styles.table}>
-                                <thead>
-                                        {table.getHeaderGroups().map((hg) => (
-                                                <tr key={hg.id}>
-                                                        {hg.headers.map((h) => (
-                                                                <th
-                                                                        key={h.id}
-                                                                        onClick={h.column.getToggleSortingHandler()}
-                                                                        className={styles.headerCell}
-                                                                >
-                                                                        {flexRender(h.column.columnDef.header, h.getContext())}
-                                                                        {h.column.getIsSorted() ? (
-                                                                                h.column.getIsSorted() === 'asc' ? ' \u25B2' : ' \u25BC'
-                                                                        ) : ''}
-                                                                </th>
-                                                        ))}
-                                                </tr>
-                                        ))}
-                                </thead>
-                                <tbody>
-                                        {table.getRowModel().rows.map((row) => (
-                                                <tr key={row.id}>
-                                                        {row.getVisibleCells().map((cell) => (
-                                                                <td key={cell.id} className={cell.column.id === 'actions' ? styles.actions : undefined}>
-                                                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                                                </td>
-                                                        ))}
-                                                </tr>
-                                        ))}
-                                </tbody>
-                        </table>
+                                        <DataTable
+                                                table={table}
+                                                getCellClassName={(id) =>
+                                                        id === 'actions' ? styles.actions : undefined
+                                                }
+                                        />
                                 </>
                         )}
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6,8 +6,8 @@
   --sidebar-color: #ffffff;
   --sidebar-text: #ffffff;
   --sidebar-hover: #23253a;
-  --accent: #7c3aed;
-  --content-bg: #f0f0f3;
+  --accent: #1a3027;
+  --content-bg: #f7f8fa;
   --border-color: #ccc;
 }
 
@@ -19,7 +19,7 @@
     --sidebar-bg: #13151f;
     --sidebar-text: #ffffff;
     --sidebar-hover: #23253a;
-    --content-bg: #1b1d2b;
+    --content-bg: #24263a;
     --border-color: #444;
   }
 }

--- a/frontend/src/components/DataTable/DataTable.module.css
+++ b/frontend/src/components/DataTable/DataTable.module.css
@@ -1,0 +1,19 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--border-color);
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.headerCell {
+  cursor: pointer;
+  user-select: none;
+}

--- a/frontend/src/components/DataTable/DataTable.tsx
+++ b/frontend/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { flexRender, Table } from '@tanstack/react-table';
+import styles from './DataTable.module.css';
+import type { RowData } from '@tanstack/react-table';
+
+interface DataTableProps<T extends RowData> {
+  table: Table<T>;
+  getCellClassName?: (columnId: string) => string | undefined;
+}
+
+function DataTable<T extends RowData>({ table, getCellClassName }: DataTableProps<T>) {
+  return (
+    <table className={styles.table}>
+      <thead>
+        {table.getHeaderGroups().map((hg) => (
+          <tr key={hg.id}>
+            {hg.headers.map((h) => (
+              <th
+                key={h.id}
+                onClick={h.column.getToggleSortingHandler()}
+                className={styles.headerCell}
+              >
+                {flexRender(h.column.columnDef.header, h.getContext())}
+                {h.column.getIsSorted() === 'asc'
+                  ? ' \u25B2'
+                  : h.column.getIsSorted() === 'desc'
+                  ? ' \u25BC'
+                  : ''}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id} className={getCellClassName?.(cell.column.id)}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default DataTable;

--- a/frontend/src/components/ReadingsTable/ReadingsTable.module.css
+++ b/frontend/src/components/ReadingsTable/ReadingsTable.module.css
@@ -3,22 +3,3 @@
   overflow-y: auto;
 }
 
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  border-radius: 8px;
-  overflow: hidden;
-  border: 1px solid var(--border-color);
-}
-
-.table th,
-.table td {
-  border: 1px solid var(--border-color);
-  padding: 8px 12px;
-  text-align: left;
-}
-
-.headerCell {
-  cursor: pointer;
-  user-select: none;
-}

--- a/frontend/src/components/ReadingsTable/ReadingsTable.tsx
+++ b/frontend/src/components/ReadingsTable/ReadingsTable.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import {
-	flexRender,
-	getCoreRowModel,
-	getSortedRowModel,
-	useReactTable,
+        getCoreRowModel,
+        getSortedRowModel,
+        useReactTable,
 } from '@tanstack/react-table';
 import { useState } from 'react';
+import DataTable from '@/components/DataTable/DataTable';
 import styles from './ReadingsTable.module.css';
 import type { Reading } from '@/services/api/types';
 import type { ColumnDef, SortingState } from '@tanstack/react-table';
@@ -42,36 +42,9 @@ function ReadingsTable({ data, isLoading }: {
 
         return (
         <div className={styles.wrapper}>
-        <table className={styles.table}>
-            <thead>
-                {table.getHeaderGroups().map((hg) => (
-                    <tr key={hg.id}>
-                        {hg.headers.map((h) => (
-                            <th
-                                key={h.id}
-                                onClick={h.column.getToggleSortingHandler()}
-                                className={styles.headerCell}
-                            >
-                                {flexRender(h.column.columnDef.header, h.getContext())}
-                                {h.column.getIsSorted() === 'asc' ? ' ▲' : h.column.getIsSorted() === 'desc' ? ' ▼' : ''}
-                            </th>
-						))}
-                    </tr>
-				))}
-            </thead>
-
-            <tbody>
-                {table.getRowModel().rows.map((row) => (
-                    <tr key={row.id}>
-                        {row.getVisibleCells().map((cell) => (
-                            <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
-						))}
-                    </tr>
-				))}
-            </tbody>
-        </table>
-    </div>
-	);
+            <DataTable table={table} />
+        </div>
+        );
 }
 
 export default ReadingsTable;

--- a/frontend/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/src/components/Sidebar/Sidebar.module.css
@@ -6,7 +6,7 @@
     display: flex;
     flex-direction: column;
     gap: 24px;
-    border-radius: 12px 0 0 12px;
+    border-radius: 0 12px 12px 0;
 }
 
 .navListItem {


### PR DESCRIPTION
## Summary
- create reusable `DataTable` component used across dashboard and sensor pages
- refactor `ReadingsTable` and `SensorsTable` to use new component
- lighten `--content-bg`, remove card shadow, adjust sidebar radius
- change accent color to `#1a3027`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a69fa06e483319002c489f3affaec