### PR TITLE
Fix sensors table layout and style anchor links

### DIFF
--- a/frontend/src/app/(dashboard)/sensors/page.module.css
+++ b/frontend/src/app/(dashboard)/sensors/page.module.css
@@ -9,3 +9,9 @@
   font-size: 24px;
   font-weight: 600;
 }
+
+.card {
+  background: var(--content-bg);
+  border-radius: 12px;
+  padding: 16px;
+}

--- a/frontend/src/app/(dashboard)/sensors/page.tsx
+++ b/frontend/src/app/(dashboard)/sensors/page.tsx
@@ -4,12 +4,14 @@ import SensorTable from '@/app/(dashboard)/sensors/_components/SensorsTable/Sens
 import styles from './page.module.css';
 
 function SensorsPage() {
-        return (
-                <main className={styles.main}>
-                        <h1 className={styles.title}>Sensors</h1>
-                        <SensorTable />
-                </main>
-        );
+  return (
+    <main className={styles.main}>
+      <h1 className={styles.title}>Sensors</h1>
+      <div className={styles.card}>
+        <SensorTable />
+      </div>
+    </main>
+  );
 }
 
 export default SensorsPage;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -45,8 +45,8 @@ body {
 }
 
 a {
-  color: inherit;
-  text-decoration: none;
+  color: var(--accent);
+  text-decoration: underline;
 }
 
 ul {


### PR DESCRIPTION
## Summary
- highlight anchor links in the global stylesheet so users notice them
- wrap the sensors table in a styled card to match the dashboard layout

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a6c964ddc8331a93a9d248aa8f2ba